### PR TITLE
Add missing dependencies to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Installation
 
 ```bash
 $ pip install -rrequirements.txt
+$ yum install virt-install
 $ python setup.py install
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 sh
+ipaddress


### PR DESCRIPTION
A clean RHEL 7 needed the ipaddress Python module and virt-install
tool to be installed too for this tool to work properly.

Signed-off-by: Martin Sivak msivak@redhat.com
